### PR TITLE
updating YArray's iterator to iterate Types correctly 

### DIFF
--- a/tests/y-array.tests.js
+++ b/tests/y-array.tests.js
@@ -209,6 +209,22 @@ test('event target is set correctly (remote user)', async function array12 (t) {
   await compareUsers(t, users)
 })
 
+test('should correctly iterate an array containing types', async function iterate1 (t) {
+  const y = new Y.Y()
+  const arr = y.define('arr', Y.Array)
+  const numItems = 10
+  for(let i = 0; i < numItems; i++) {
+    const map = new Y.Map()
+    map.set('value', i)
+    arr.push([map])
+  }
+  let cnt = 0
+  for(let item of arr) {
+    t.assert(item.get('value') === cnt++, 'value is correct')
+  }
+  y.destroy()
+})
+
 var _uniqueNumber = 0
 function getUniqueNumber () {
   return _uniqueNumber++

--- a/types/YArray.js
+++ b/types/YArray.js
@@ -189,6 +189,7 @@ export class YArray extends Type {
         let content
         if (this._item instanceof Type) {
           content = this._item
+          this._item = this._item._right
         } else {
           content = this._item._content[this._itemElement++]
         }


### PR DESCRIPTION
Looks like it was missing a switching to the next item after processing a Type item, so once iterator met a Type it stuck on it. If more tests or something else is required I will be happy to do that.